### PR TITLE
Containerize all the checks under the "test" stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,2 @@
-language: Python
-Python:
-  - "3.7"
-before_install:
-  # require for installing pyodbc
-  - sudo apt-get install unixodbc-dev
-# command to setup datamegh
-install:
-  - make setup
-# check for black format
-# build will stop if check fail 
-before_script:
-  - black --check --diff . 
 script:
-  - make setup
   - make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,27 @@ FROM base AS main
 # -----------
 # Image used for running tests.
 FROM base AS test
-RUN pip install .[dev]
+
+ENV NODE_VERSION 12.14.1
+
+RUN apt-get update \
+  && apt-get install -y curl xz-utils \
+  && curl -O https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz \
+  && mkdir -p /usr/local/lib/nodejs \
+  && tar -xJf node-v${NODE_VERSION}-linux-x64.tar.xz -C /usr/local/lib/nodejs \
+  && rm node-v${NODE_VERSION}-linux-x64.tar.xz \
+  && apt-get remove -y curl libcurl4 libnghttp2-14 libpsl5 librtmp1 libssh2-1 publicsuffix xz-utils \
+  && apt-get autoremove -y \
+  && apt-get autoclean -y \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PATH "$PATH:/usr/local/lib/nodejs/node-v${NODE_VERSION}-linux-x64/bin:/source/node_modules/.bin"
+
+COPY ["package.json", "package-lock.json", "pyrightconfig.json", "./"]
+
+RUN pip install .[dev] && npm install
 
 COPY ["tests", "./"]
 
-CMD pytest -vvv
+# Test the code is good, types are safe and tests are passing.
+CMD black --check --diff . && pyright && pytest -vvv

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,7 @@ RUN pip install .[dev] && npm install
 COPY ["tests", "./"]
 
 # Test the code is good, types are safe and tests are passing.
-CMD black --check --diff . && pyright && pytest -vvv
+CMD \
+  echo "\nRUNNING CODE STYLE CHECK (BLACK)" && black --check --diff . && \
+  echo "\nRUNNING TYPE CHECKS" && pyright && \
+  echo "\nRUNNING TESTS" && pytest -vvv

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,5 @@ build:
 test:
 	@docker build --target=test -t datamegh:test .
 	@docker run datamegh:test
-	@npm run typecheck
 
 .PHONY: all test clean


### PR DESCRIPTION
- Move all the checks (code style, type check and tests) into the same docker "test" stage.
- Running `make test` would run all these checks inside a container regardless of what your local host machine has.
  - This means no matter where you run `make test`, it performs the same way - no dependency with your host system.
  - Theoretically speaking, this requires no dependency at all - neither on your host machine, nor on CI nor on server / any platform - they only reside inside your container. 
- Clean up travis configuration - it just needs to run `make test` - it will do the job.

Note: However, for your code editor support you'd still need to have depedencies - this requires further research on how this could be reduced.

---
Here's how it looks like:
![image](https://user-images.githubusercontent.com/3315763/74682716-f43e2080-51ee-11ea-9b10-3afe6a81d483.png)
