### PR TITLE
Makefile improvements - `all` rule is not defined to be executed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,4 @@ check:
 	@black --check --diff .
 	@pyright
 
-.PHONY: all test clean
+.PHONY: test clean


### PR DESCRIPTION
No rule is defined for the target `all`. 
When we run `make all` , it throws the following exception.
![all](https://i.imgur.com/yW83UUl.png)