### PR TITLE
Change pyright command to npm script in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,6 @@ format:
 
 check:
 	@black --check --diff .
-	@pyright
+	@npm run typecheck
 
 .PHONY: test clean


### PR DESCRIPTION
In makefile, under check target, pyright is called directly. Since,
pyright is a npm package and we have typecheck script in package.json
file, the command is changed to npm script.