### PR TITLE
Remove .venv entry from exclude list.

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,6 +1,6 @@
 {
   "include": ["datamegh/**/*.py", "tests/**/*.py"],
-  "exclude":[".venv", "venv", "*.pyc", "*.egg-info", ".coverage"],
+  "exclude":["venv", "*.pyc", "*.egg-info", ".coverage"],
   "reportMissingImports": true,
   "strict":["datamegh", "tests"]
 }


### PR DESCRIPTION
`.venv` is ignored by default with pyright. Removed the entry of `.venv` from `exclude` list.

**Reference**: 
[pyright Config Options](https://github.com/microsoft/pyright/blob/master/docs/configuration.md#master-pyright-config-options)