### PR TITLE
Add list_to_dict util to convert list to dictionary with custom keys

### DIFF
--- a/datamegh/util/object.py
+++ b/datamegh/util/object.py
@@ -4,13 +4,15 @@ import collections
 import flatten_json
 
 from copy import deepcopy
+from typing import Dict, List
 
 from datamegh.util.types import is_dict, is_iterable, is_string, is_list
 
 
-def dict_to_list(dict):
+def dict_to_list(dict: Dict, name_key: str = "name", value_key: str = "value"):
     """
-    Returns a list of dictionaries with `name` and `value` keys for all key-value pair in given dictionary.
+    Returns a list of dictionaries with `name` and `value` keys for all
+    key-value pair in given dictionary.
     """
     if not is_dict(dict):
         raise AttributeError(
@@ -22,9 +24,27 @@ def dict_to_list(dict):
     list = []
 
     for key, val in dict.items():
-        list.append({"name": key, "value": val})
+        list.append({name_key: key, value_key: val})
 
     return list
+
+
+def list_to_dict(list: List, name_key: str = "name", value_key: str = "value"):
+    """
+    Returns a key-value pair dictionary with given list of dictionary having
+    `name` and `value` keys or custom keys.
+    """
+    if not is_list(list):
+        raise AttributeError(
+            "Argument must be a list, invalid argument received '{}'.".format(list)
+        )
+
+    dict = {}
+
+    for item in list:
+        dict[item[name_key]] = item[value_key]
+
+    return dict
 
 
 def merge(dict1, dict2):

--- a/tests/util/test_object.py
+++ b/tests/util/test_object.py
@@ -31,6 +31,16 @@ def test_dict_to_list_returns_list_when_valid_arguments_is_dict():
     assert dict_to_list(value) == expected
 
 
+def test_dict_to_list_return_dict_with_custom_keys():
+    """ Cases of dict_to_list() with custom `keys` """
+    items = {"test101.txt": 23, "test201.txt": 24}
+
+    assert dict_to_list(items, "key", "size") == [
+        {"key": "test101.txt", "size": 23},
+        {"key": "test201.txt", "size": 24},
+    ]
+
+
 def test_dict_to_list_returns_empty_list_when_argument_is_empty_dict():
     """
     Test an empty dictionary converted to empty list.

--- a/tests/util/test_object.py
+++ b/tests/util/test_object.py
@@ -6,6 +6,7 @@ from datamegh.util.object import (
     delinearize,
     merge,
     dict_to_list,
+    list_to_dict,
     without_attr,
     with_only,
 )
@@ -48,6 +49,44 @@ def test_dict_to_list_raises_exception_when_argument_is_invalid():
         ex.value.args[0]
         == "Argument must be a dictionary, invalid argument received '1'."
     )
+
+
+def test_list_to_dict_returns_dict_when_valid_arguments_is_list():
+    """ Simple cases for list_to_dict() """
+    dict_items = {"mode": 16877, "size": 64, "name": "timesheet", "is_file": False}
+
+    list_items = [
+        {"name": "mode", "value": 16877},
+        {"name": "size", "value": 64},
+        {"name": "name", "value": "timesheet"},
+        {"name": "is_file", "value": False},
+    ]
+
+    assert list_to_dict(list_items) == dict_items
+
+
+def test_list_to_dict_return_dict_with_custom_keys():
+    """ Case of list_to_dict() with custom `keys` """
+    items = [{"key": "test101.txt", "size": 23}, {"key": "test201.txt", "size": 24}]
+
+    assert list_to_dict(items, "key", "size") == {"test101.txt": 23, "test201.txt": 24}
+
+
+def test_list_to_dict_returns_empty_dict_when_argument_is_empty_list():
+    """
+    Test an empty dictionary converted to empty list.
+    """
+    assert list_to_dict([]) == {}
+
+
+def test_list_to_dict_raises_exception_when_argument_is_invalid():
+    """
+    Test an invalid argument such as int to list_to_dict
+    """
+    with pytest.raises(AttributeError) as ex:
+        list_to_dict(1)
+
+    assert ex.value.args[0] == "Argument must be a list, invalid argument received '1'."
 
 
 def test_linearize_1():


### PR DESCRIPTION
- Improve `dict_to_list` util to accept custom keys.
- Add list_to_dict util to convert list to the dictionary with custom keys